### PR TITLE
feature/#10-route_api: 카카오맵, 티맵 api 데이터 가공

### DIFF
--- a/places/serializers.py
+++ b/places/serializers.py
@@ -1,17 +1,41 @@
 from rest_framework import serializers
 from .models import *
 
+# 1.1 현위치 표시
 class PlaceSerializer(serializers.ModelSerializer):
   class Meta:
     model = Place
     fields = ['longitude', 'latitude']
-
 class DongResponseSerializer(serializers.Serializer):
     dong = serializers.CharField(help_text="행정동(법정동) 명칭")
     code = serializers.CharField(help_text="행정코드", required=False)
+
+# 6.1 등록된 카드의 동선 안내
+class PointSerializer(serializers.Serializer):
+    x = serializers.FloatField(help_text='경도')
+    y = serializers.FloatField(help_text='위도')
+class PlaceRouteSerializer(serializers.ModelSerializer):
+  class Meta:
+    model = Place
+    fields = ['transport','origin', 'destination', 'waypoints', 'priority', 'alternatives']
+
+  transport = serializers.ChoiceField(choices=["car", "transit"], help_text="'car'=카카오 내비, 'transit'=티맵 대중교통")
+  origin = PointSerializer()
+  destination = PointSerializer()
+  waypoints = PointSerializer(many=True, required=False, allow_empty=True)
+  priority = serializers.ChoiceField(choices=['RECOMMEND','TIME', 'DISTANCE'], required=False)
+  alternatives = serializers.BooleanField(default=True)
+
+  def validate_waypoints(self, value):
+      if value is None:
+          return []
+      if len(value) > 25:
+          raise serializers.ValidationError("경유지(waypoints)는 최대 25개까지 허용됩니다.")
+      return value
 
 class ReviewSerializer(serializers.ModelSerializer):
   class Meta:
     model = Review
     fields = '__all__'
     read_only_fields = ["ai_review"]
+

--- a/places/services/kakao.py
+++ b/places/services/kakao.py
@@ -1,13 +1,45 @@
 import requests
 from django.conf import settings
 
-BASE = "https://dapi.kakao.com/v2/local"
+LOCAL = "https://dapi.kakao.com/v2/local"
+ROUTE = "https://apis-navi.kakaomobility.com/v1/waypoints/directions"
 
 def _headers():
     return {"Authorization": f"KakaoAK {settings.KAKAO_REST_API_KEY}"}
 
+# 1.1 현위치 표시
 def locate_dong(x, y): 
     params = {"x":x, "y":y}
-    r = requests.get(f"{BASE}/geo/coord2regioncode.json", headers=_headers(), params=params, timeout=5)
-    r.raise_for_status()
+    r = requests.get(f"{LOCAL}/geo/coord2regioncode.json", headers=_headers(), params=params, timeout=5)
+    r.raise_for_status() #200대가 아니면 에러 발생
     return r.json() 
+
+
+# 6.1 등록된 카드의 동선 안내(택시, 자동차)
+def car_route(origin, destination, waypoints=None, priority="RECOMMEND", alternatives=True):
+    params = {
+         "origin": {
+            "x": origin[0],
+            "y": origin[1]
+        },
+        "destination": {
+            "x": destination[0],
+            "y": destination[1]
+        },
+        "priority": priority,
+        "alternatives": alternatives,
+    }
+
+    # 경유지
+    if waypoints:
+        params["waypoints"] = [
+            {
+                "x": wp[0],
+                "y": wp[1]
+            }
+            for wp in waypoints
+        ]
+
+    r = requests.post(f"{ROUTE}", headers=_headers(), json=params, timeout=5)
+    r.raise_for_status()
+    return r.json()

--- a/places/services/tmap.py
+++ b/places/services/tmap.py
@@ -1,0 +1,27 @@
+import requests
+from django.conf import settings
+
+BASE = "https://apis.openapi.sk.com/transit/routes"
+
+def _headers():
+    return {
+            "appKey": settings.TMAP_API_KEY,
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+    }
+
+# 6.1 등록된 카드의 동선 안내(대중교통)
+def traffic_route(startX, startY, endX, endY, lang=0, format="json", count=5): 
+    payload = {
+        "startX":startX, 
+        "startY":startY, 
+        "endX":endX, 
+        "endY":endY,
+        "lang": lang,
+        "format": format,
+        "count": count
+    }
+
+    r = requests.post(BASE, headers=_headers(), json=payload, timeout=5)
+    r.raise_for_status() #200대가 아니면 에러 발생
+    return r.json() 

--- a/places/urls.py
+++ b/places/urls.py
@@ -10,6 +10,10 @@ app_name = "places"
 default_router = routers.SimpleRouter(trailing_slash=False)
 default_router.register("places", PlaceViewSet, basename="places")
 
+route_router = routers.SimpleRouter(trailing_slash=False)
+route_router.register("routes", PlaceRouteViewSet, basename="routes")
+
 urlpatterns = [
     path("", include(default_router.urls)),
+    path("", include(route_router.urls)),
 ] + static(settings.MEDIA_URL, document_root = settings.MEDIA_ROOT)

--- a/project/settings.py
+++ b/project/settings.py
@@ -19,6 +19,7 @@ from dotenv import load_dotenv
 BASE_DIR = Path(__file__).resolve().parent.parent
 load_dotenv(BASE_DIR / ".env")
 KAKAO_REST_API_KEY = os.getenv("KAKAO_REST_API_KEY")
+TMAP_API_KEY = os.getenv("TMAP_API_KEY")
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용

카카오맵, 티맵 api 데이터 불러와서 가공하였습니다.
- 카카오맵: 택시요금, 거리, 차량소요시간
- 티맵: 대중교통거리, 시간, 환승횟수, 요금, 도보(시간/거리/걸음), 지하철/버스(노선, 번호)

## 📸 스크린샷

- 카카오맵 반환 화면
<img width="887" height="563" alt="스크린샷 2025-08-09 211251" src="https://github.com/user-attachments/assets/1eb291cc-fe42-4684-adf9-99bcc39ec13d" />
- 카카오맵, 티맵 json 요청 양식
<img width="671" height="874" alt="스크린샷 2025-08-09 211306" src="https://github.com/user-attachments/assets/162c937f-d228-48bd-9e4f-1ecad488263d" />


## 🖥️ 주요 코드 설명
- seriallizers.py : PlaceRouteSerializer 추가하여 카카오맵, 티맵 api 필드 추가
- kakao.py, tmap.py : api 요청 양식 맞춰 작성
- views.py : 응답받은 데이터 가공하여 json 반환 

## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 📟 관련 이슈

- Resolved: #10 
