### PR TITLE
Feature/#12 mainpage_api: 구글 장소 리스트, 카카오 카테고리 추천 구현

### DIFF
--- a/places/serializers.py
+++ b/places/serializers.py
@@ -10,6 +10,14 @@ class DongResponseSerializer(serializers.Serializer):
     dong = serializers.CharField(help_text="행정동(법정동) 명칭")
     code = serializers.CharField(help_text="행정코드", required=False)
 
+# 1.2 구글 장소 검색
+class PlaceSearchSerializer(serializers.Serializer):
+    q = serializers.CharField(source="text_query")  # API에 넘길 키 이름 매핑
+    x = serializers.FloatField()   # 경도
+    y = serializers.FloatField()   # 위도
+    radius = serializers.IntegerField(required=False, default=2000) # 미터단위, 기본 2km
+    priceLevel = serializers.CharField(required=False, allow_null=True)
+
 # 6.1 등록된 카드의 동선 안내
 class PointSerializer(serializers.Serializer):
     x = serializers.FloatField(help_text='경도')
@@ -38,4 +46,3 @@ class ReviewSerializer(serializers.ModelSerializer):
     model = Review
     fields = '__all__'
     read_only_fields = ["ai_review"]
-

--- a/places/serializers.py
+++ b/places/serializers.py
@@ -11,12 +11,21 @@ class DongResponseSerializer(serializers.Serializer):
     code = serializers.CharField(help_text="행정코드", required=False)
 
 # 1.2 구글 장소 검색
-class PlaceSearchSerializer(serializers.Serializer):
-    q = serializers.CharField(source="text_query")  # API에 넘길 키 이름 매핑
+class PlaceMixin(serializers.Serializer):
     x = serializers.FloatField()   # 경도
     y = serializers.FloatField()   # 위도
-    radius = serializers.IntegerField(required=False, default=2000) # 미터단위, 기본 2km
+    radius = serializers.IntegerField(required=False, default=2000)
+
+class PlaceSearchSerializer(PlaceMixin):
+    q = serializers.CharField(source="text_query")  # API에 넘길 키 이름 매핑
     priceLevel = serializers.CharField(required=False, allow_null=True)
+
+# 1.2 장소 카테고리별 추천
+class PlaceRecommendSerializer(PlaceMixin): 
+    radius = serializers.IntegerField(required=True)
+    category_group_code = serializers.CharField(required=False)
+    limit = serializers.IntegerField(required=False, default=10)
+    # 인기순 관련 : 검색어가 비슷한 것끼리 모델에 저장되어 카운트?
 
 # 6.1 등록된 카드의 동선 안내
 class PointSerializer(serializers.Serializer):

--- a/places/services/google.py
+++ b/places/services/google.py
@@ -1,0 +1,76 @@
+import requests
+from django.conf import settings
+
+BASE = "https://places.googleapis.com/v1/places"
+
+
+def _headers():
+    return {
+        "X-Goog-Api-Key": settings.GOOGLE_API_KEY,
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "X-Goog-FieldMask": "places.displayName,places.id,places.nationalPhoneNumber,places.location,places.regularOpeningHours,places.rating,places.photos,places.priceRange,places.formattedAddress,places.types,places.reviews,places.priceLevel",
+    }
+
+# 1.2 구글 검색기준을 이용해 장소를 검색하여 리스트를 반환
+def search_place(text_query, x, y, radius, priceLevel=None):
+    body = {
+        "textQuery": text_query,
+        "languageCode": "ko",
+        "regionCode": "KR",
+        "locationBias": {
+            "circle": {
+                "center": {"latitude": y, "longitude": x},
+                "radius": radius,  # 반경거리
+            }
+        },
+        "priceLevels": priceLevel,  # 가격대 "PRICE_LEVEL_INEXPENSIVE", "PRICE_LEVEL_MODERATE"
+    }
+    r = requests.post(f"{BASE}:searchText", headers=_headers(), json=body, timeout=5)
+    r.raise_for_status()  # 200대가 아니면 에러 발생
+
+    data = r.json()
+    places = data.get("places", [])
+
+    google_place = []
+    for p in places:
+
+        photos = p.get("photos", [])
+        place_photos = {
+            build_photo_url(p["name"], max_width_px=800)
+            for p in photos
+            if p.get("name")
+        }
+
+        reviews = p.get("reviews", [])
+        reviews_text = [
+            r.get("text", {}).get("text")  
+            for r in reviews #리뷰 상한 필요시 [:5]
+            if r.get("text", {}).get("text")
+        ]
+
+        google_place.append({
+            "place_id" : p.get("id"),
+            "place_name" : p.get("displayName", {}).get("text"),
+            "address" : p.get("formattedAddress"),
+            "location" : p.get("location"),
+            "types" : p.get("types"),
+            "phone_number" : p.get("nationalPhoneNumber"),
+            "rating" : p.get("rating"),
+            "open_now" : p.get("regularOpeningHours", {}).get("openNow"),
+            "running_time" : p.get("regularOpeningHours", {}).get("weekdayDescriptions"),
+            "price_range_start" : p.get("priceRange", {}).get("startPrice", {}).get("units"),
+            "price_range_end" : p.get("priceRange", {}).get("endPrice", {}).get("units"),
+            "place_photos" : place_photos,
+            "reviews_text" : reviews_text
+        })
+    
+    return google_place
+
+
+# 사진 URL 생성
+def build_photo_url(photo_name: str, max_width_px: int = 800) -> str:
+    return (
+        f"https://places.googleapis.com/v1/{photo_name}/media"
+        f"?key={settings.GOOGLE_API_KEY}&maxWidthPx={max_width_px}"
+    )

--- a/places/services/google.py
+++ b/places/services/google.py
@@ -33,7 +33,7 @@ def search_place(text_query, x, y, radius, priceLevel=None):
     places = data.get("places", [])
 
     google_place = []
-    for p in places:
+    for p in places: #장소 리스트 상한 필요시 [:5]
 
         photos = p.get("photos", [])
         place_photos = {

--- a/places/services/kakao.py
+++ b/places/services/kakao.py
@@ -14,6 +14,19 @@ def locate_dong(x, y):
     r.raise_for_status() #200대가 아니면 에러 발생
     return r.json() 
 
+# 1.2 장소 카테고리별 추천
+# 1) 구글 장소의 위도경도를 이용하여 카카오맵에 검색하여 카테고리 확인
+# 2) 그 외 카테고리별 장소 반환
+def recommend_place(category_group_code, x, y, radius):
+    params = {
+        "category_group_code" : category_group_code,
+        "x" : x,
+        "y" : y,
+        "radius" : radius
+    }
+    r = requests.get(f"{LOCAL}/search/category.json", headers=_headers(), params=params, timeout=5)
+    r.raise_for_status() 
+    return r.json() 
 
 # 6.1 등록된 카드의 동선 안내(택시, 자동차)
 def car_route(origin, destination, waypoints=None, priority="RECOMMEND", alternatives=True):

--- a/places/services/kakao.py
+++ b/places/services/kakao.py
@@ -37,8 +37,9 @@ def _search_category(category, x, y, radius, size=10):
 def recommend_place(x, y, radius, category_group_code=None, limit=10):
     if not category_group_code or category_group_code == "all":
         codes = CATEGORY
+        limit = 3 #검색창 하단 카테고리 추천 수 제한
     else:
-        codes = [category_group_code]
+        codes = [category_group_code] #카테고리 페이지에서는 10개씩 default
 
     results = {
         code: _search_category(code, x, y, radius, size=limit) 

--- a/places/services/kakao.py
+++ b/places/services/kakao.py
@@ -7,12 +7,12 @@ ROUTE = "https://apis-navi.kakaomobility.com/v1/waypoints/directions"
 def _headers():
     return {"Authorization": f"KakaoAK {settings.KAKAO_REST_API_KEY}"}
 
-# 1.1 현위치 표시
+# 1.1 현위치 표시 / region_3depth_name => ‘○○동’
 def locate_dong(x, y): 
     params = {"x":x, "y":y}
     r = requests.get(f"{LOCAL}/geo/coord2regioncode.json", headers=_headers(), params=params, timeout=5)
     r.raise_for_status() #200대가 아니면 에러 발생
-    return r.json() 
+    return r.json()
 
 # 1.2 장소 카테고리별 추천
 CATEGORY = ["CT1", "AT4", "FD6", "CE7"] # 문화시설, 관광명소, 음식점, 카페

--- a/places/services/kakao.py
+++ b/places/services/kakao.py
@@ -15,18 +15,36 @@ def locate_dong(x, y):
     return r.json() 
 
 # 1.2 장소 카테고리별 추천
-# 1) 구글 장소의 위도경도를 이용하여 카카오맵에 검색하여 카테고리 확인
-# 2) 그 외 카테고리별 장소 반환
-def recommend_place(category_group_code, x, y, radius):
+CATEGORY = ["CT1", "AT4", "FD6", "CE7"] # 문화시설, 관광명소, 음식점, 카페
+def _search_category(category, x, y, radius, size=10):
     params = {
-        "category_group_code" : category_group_code,
-        "x" : x,
-        "y" : y,
-        "radius" : radius
+        "category_group_code": category,
+        "x": x,
+        "y": y,
+        "radius": radius,
+        "size":size,
     }
     r = requests.get(f"{LOCAL}/search/category.json", headers=_headers(), params=params, timeout=5)
-    r.raise_for_status() 
-    return r.json() 
+    r.raise_for_status()
+    places = (r.json() or {}).get("documents", [])
+
+    # 2) place_name, x, y 반환 => 구글 장소 세부데이터 요청 필요 (places/google_place)
+    return [
+        {"place_name": p.get("place_name"), "x": p.get("x"), "y": p.get("y")}
+        for p in places[:size] #장소 리스트 상한 10개
+    ]
+
+def recommend_place(x, y, radius, category_group_code=None, limit=10):
+    if not category_group_code or category_group_code == "all":
+        codes = CATEGORY
+    else:
+        codes = [category_group_code]
+
+    results = {
+        code: _search_category(code, x, y, radius, size=limit) 
+        for code in codes
+    }
+    return results[codes[0]] if len(codes) == 1 else results
 
 # 6.1 등록된 카드의 동선 안내(택시, 자동차)
 def car_route(origin, destination, waypoints=None, priority="RECOMMEND", alternatives=True):

--- a/places/views.py
+++ b/places/views.py
@@ -9,7 +9,6 @@ from .serializers import *
 from .services import kakao, tmap, google, openai
 
 import requests
-import json
 
 from django.shortcuts import get_object_or_404
 
@@ -18,48 +17,37 @@ class PlaceViewSet(viewsets.ViewSet):
   # 1.1 현위치 표시 (프론트에서 처리가능할 수도 있음, 확인 후 삭제 예정)
   @extend_schema(
     tags = ["1.1 현위치 표시"],
-    parameters=[
-      OpenApiParameter(name="x", description="경도", required=True, type=float),
-      OpenApiParameter(name="y", description="위도", required=True, type=float),
-    ],
+    parameters=[PlaceSerializer],
     responses={200: DongResponseSerializer},
     description="클라이언트 위치(경도, 위도) 기준 카카오 동 반환",
   )
-
   @action(detail=False, methods=["GET"])
   def locate(self, request):
-    x = request.query_params.get("x")
-    y = request.query_params.get("y")
+    query = PlaceSerializer(data=request.query_params)
+    query.is_valid(raise_exception=True)
+    x = query.validated_data["latitude"]
+    y = query.validated_data["longitude"]
 
     try:
-        data = kakao.locate_dong(x=float(x), y=float(y))
+        data = kakao.locate_dong(x=x, y=y)
     except ValueError:
         return Response({"detail": "경도/위도는 숫자여야 합니다."}, status=400)
     except requests.RequestException as e:
         return Response({"detail": f"카카오 API 호출 실패: {e}"}, status=502)
-
-    # Kakao 응답에서 동 이름 뽑기 (region_3depth_name => ‘○○동’)
+    
     docs = data.get("documents", [])
     if docs:
-        primary = docs[0]
-        dong = primary.get("region_3depth_name")
-        code = primary.get("code") #코드는 필요없을 수 있음 확인 후 삭제 예정
-
+        dong = docs[0].get("region_3depth_name")
     if not dong:
         return Response({"detail": "동 정보를 찾지 못했습니다."}, status=404)
-    return Response({"dong": dong, "code": code}, status=200)
+    
+    return Response({"dong": dong}, status=200)
 
   # 1.2 구글 장소 검색 → place 정보 반환
   @extend_schema(
     tags=["1.2 구글 장소 검색"],
-    parameters=[
-        OpenApiParameter(name="q", description="검색어(textQuery)", required=True, type=str),
-        OpenApiParameter(name="x", description="경도", required=True, type=float),
-        OpenApiParameter(name="y", description="위도", required=True, type=float),
-        OpenApiParameter(name="radius", description="반경거리", required=False, type=float), #거리
-        OpenApiParameter(name="priceLevel", description="가격", required=False, type=str), #가격 "PRICE_LEVEL_INEXPENSIVE", "PRICE_LEVEL_MODERATE"
-        #후기, #인기순 정렬 코드 작성 필요
-    ],
+    parameters=[PlaceSearchSerializer],
+    #후기, #인기순 정렬 코드 작성 필요
     description="Google Places API textSearch를 이용해 place 정보 반환",
   )
   @action(detail=False, methods=["GET"])
@@ -84,31 +72,19 @@ class PlaceViewSet(viewsets.ViewSet):
   # 1) 검색한 구글 장소의 위도경도로 카테고리별 10개씩 추출
   @extend_schema(
     tags = ["1.2 장소 카테고리별 추천"],
-    parameters=[
-      OpenApiParameter(name="x", description="경도", required=True, type=float),
-      OpenApiParameter(name="y", description="위도", required=True, type=float),
-      OpenApiParameter(name="category_group_code", description="카테고리 코드", required=False, type=str),
-      OpenApiParameter(name="radius", description="반경거리", required=True, type=int),
-    ],
+    parameters=[PlaceRecommendSerializer],
     description="구글 장소의 위도경도를 이용하여 카테고리별 장소 반환",
   )
 
   #CT1 문화시설, AT4 관광명소, FD6 음식점, CE7 카페
   @action(detail=False, methods=["GET"])
   def recommend(self, request):
-    x = request.query_params.get("x")
-    y = request.query_params.get("y")
-    category = request.query_params.get("category_group_code")
-    radius = request.query_params.get("radius")
-    limit = int(request.query_params.get("limit") or 10)
-
-    if not (x and y):
-        return Response({"detail": "경도, 위도가 필요합니다."}, status=400)
-    if category is None:
-        category = request.query_params.get("category")
+    query = PlaceRecommendSerializer(data=request.query_params)
+    query.is_valid(raise_exception=True)
+    params = query.validated_data
 
     try:
-        data = kakao.recommend_place(x=float(x), y=float(y), category_group_code=category, radius=radius, limit=limit)
+        data = kakao.recommend_place(**params)
     except requests.RequestException as e:
         return Response({"detail": f"카카오 API 호출 실패: {e}"}, status=502)
 

--- a/project/settings.py
+++ b/project/settings.py
@@ -20,6 +20,8 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 load_dotenv(BASE_DIR / ".env")
 KAKAO_REST_API_KEY = os.getenv("KAKAO_REST_API_KEY")
 TMAP_API_KEY = os.getenv("TMAP_API_KEY")
+GOOGLE_API_KEY = os.getenv("GOOGLE_API_KEY")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -64,6 +66,10 @@ SPECTACULAR_SETTINGS = {
   'COMPONENT_SPLIT_REQUEST': True, # 웹에서 파일 업로드 기능
   'SWAGGER_UI_DIST': 'SIDECAR', # 정적파일 경로
   'REDOC_DIST': 'SIDECAR',
+  "SWAGGER_UI_SETTINGS": {
+        "operationsSorter": "alpha",  # API operation을 이름순 정렬
+        "tagsSorter": "alpha",        # 태그를 이름순 정렬
+    },
 
   'CONTACT': {
     'name': 'Sein Oh',


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
- 구글 장소 검색 시 리스트 조회
- 카카오 장소 카테고리별 추천

## 🚨 참고 사항
- 장소 리스트 정렬 기준 중 후기는 위키 페이지 확인 후 def 추가 예정이고
인기순은 검색어를 DB에 저장할 때 홍대나 홍대입구나 다른 검색어로 인식될 것 같아서 고민 중입니다.. 
https://velog.io/@top1506/Redis%EB%A5%BC-%EC%9D%B4%EC%9A%A9%ED%95%9C-%EC%9D%B8%EA%B8%B0%EA%B2%80%EC%83%89%EC%96%B4-%EB%A7%8C%EB%93%A4%EA%B8%B0Nest-js

## 📸 스크린샷
- Google Places API textSearch를 이용해 place 정보 반환
<img width="877" height="428" alt="스크린샷 2025-08-12 174642" src="https://github.com/user-attachments/assets/e14f63db-c118-43d9-baf7-58f0252520aa" />
- 구글 장소의 위도경도를 이용하여 카테고리별 장소 반환
<img width="822" height="421" alt="스크린샷 2025-08-12 174655" src="https://github.com/user-attachments/assets/01ce4cb2-606a-423d-b87b-c5848ddec277" />

## 🖥️ 주요 코드 설명
- serializers.py 구글 장소 검색 및 카카오 카테고리 추천 필드 작성
- google.py,  kakao.py API 연결코드 작성
- views.py  def locate, google_place, recommend 함수 작성

## ✅ Check List

- [ ] Merge 대상 브랜치가 올바른가?
- [ ] 최종 코드가 에러 없이 잘 동작하는가?
- [ ] 전체 변경사항이 500줄을 넘지 않는가?

## 📟 관련 이슈

- Resolved: #12 
