### PR TITLE
Refector/#29: api 테스트 서버경로 변경, 알고리즘 추천 로직, 영업시간 open/close 예외처리

### DIFF
--- a/core/times.py
+++ b/core/times.py
@@ -9,10 +9,24 @@ def format_running(running_time):
     all_breaks = []  # 모든 요일의 브레이크 타임을 저장할 리스트
     
     for d in range(7):
-        day_periods = [ 
-            p for p in running_time.get("periods", []) 
-            if p.get("open") and p["open"].get("day") == d 
-        ]
+        day_periods = []
+        try:
+            # 예외처리: open과 close가 모두 있는 경우만 추가
+            day_periods = [
+                p for p in running_time.get("periods", []) 
+                if p.get("open") and p.get("close") and 
+                p["open"].get("day") == d and 
+                p["open"].get("hour") is not None and 
+                p["open"].get("minute") is not None and
+                p["close"].get("hour") is not None and
+                p["close"].get("minute") is not None
+            ]
+        except Exception as e:
+            # 예외 발생 시 해당 요일은 정보 없음으로 처리
+            result.append(f"{DAYS[d]} 정보 없음")
+            all_breaks.append([])
+            continue
+        
         # day 값이 없으면 휴무일
         if not day_periods:
             result.append(f"{DAYS[d]} 휴무일")

--- a/places/services/kakao.py
+++ b/places/services/kakao.py
@@ -88,6 +88,7 @@ def recommend_place(x, y, radius=2000, category_group_code=None, limit=7):
 
         for p in places:
             try:
+                # 카카오 recommend 후 구글 search_place
                 res = google.search_place(
                     text_query = p["place_name"],
                     x = float(p["x"]),
@@ -108,7 +109,26 @@ def recommend_place(x, y, radius=2000, category_group_code=None, limit=7):
     # 단일 카테고리인 경우 해당 결과만 반환, 아니면 전체 결과 반환
     return results[CATEGORY_LABELS[codes[0]]] if len(codes) == 1 else results
 
-# 카카오 recommend 후 구글 search_place(리뷰순정렬)
+# 6.2 AI 루트 추천 관련 카테고리 검색
+def look_category(q, x, y, radius, size=1):
+    params = {
+        "query": q,
+        "x": x,
+        "y": y,
+        "radius": radius,
+        "size":size,
+    }
+    r = requests.get(f"{LOCAL}/search/keyword.json", headers=_headers(), params=params, timeout=5)
+    r.raise_for_status()
+    data = (r.json() or {}).get("documents", [])
+    
+    if data and len(data) > 0:
+        data_type = data[0].get("category_group_code", "")
+        return data_type
+    else:
+        # 데이터가 없는 경우 기본값(음식점) 반환
+        return "FD6"
+
 # def many_review_sort(place_list):
 #     review_sort = []
 #     for p in place_list:  # 각 장소 딕셔너리 순회

--- a/places/services/tsp_route.py
+++ b/places/services/tsp_route.py
@@ -35,8 +35,8 @@ def find_nearest_place(places, mylat, mylng):
     nearest_idx = 0
     
     for i, place in enumerate(places):
-        lat = place["location"]["latitude"]
-        lng = place["location"]["longitude"]
+        lat = float(place["location"]["latitude"])
+        lng = float(place["location"]["longitude"])
         distance = calculate_distance(mylat, mylng, lat, lng)
         
         if distance < min_distance:

--- a/places/services/tsp_route.py
+++ b/places/services/tsp_route.py
@@ -1,0 +1,175 @@
+import networkx as nx
+from core.distance import calculate_distance
+from .kakao import look_category
+
+
+def filter(day, data):
+  result = []
+
+  for place_id, place_info in data.items():
+    times = place_info.get("running_time", [])
+    name = place_info.get('place_name')
+    location = place_info.get('location')
+
+    # 해당 요일 라인만 추출
+    filter_data = [line for line in times if line.startswith(day)]
+
+    # 휴무일 체크
+    is_closed = any("휴무" in line for line in filter_data)
+
+    # 카카오 카테고리 검색
+    data_type = look_category(name, location.get("x"), location.get("y"), radius=2000)
+
+    if filter_data and not is_closed: #해당 요일에 영업 중인 장소의 데이터 반환
+      result.append({
+          "place_name": name,
+          "times": filter_data,
+          "location":location,
+          "type": data_type
+      })
+  
+  return result
+
+def find_nearest_place(places, mylat, mylng):
+    min_distance = 0
+    nearest_idx = 0
+    
+    for i, place in enumerate(places):
+        lat = place["location"]["latitude"]
+        lng = place["location"]["longitude"]
+        distance = calculate_distance(mylat, mylng, lat, lng)
+        
+        if distance < min_distance:
+            min_distance = distance
+            nearest_idx = i
+            
+    return nearest_idx
+
+def build_distance_matrix(places, mylat=None, mylng=None):
+    # 2차원 km 리스트로 반환
+    n = len(places)
+    G = nx.complete_graph(n)
+    # M = [[0]*n for _ in range(n)]
+
+    # 노드 데이터
+    for i, p in enumerate(places):
+        G.nodes[i]["latitude"] = p["location"]["latitude"]
+        G.nodes[i]["longitude"] = p["location"]["longitude"]
+
+    for i in range(n):
+        for j in range(i+1, n):
+            d = calculate_distance(G.nodes[i]["latitude"], G.nodes[i]["longitude"],
+                                   G.nodes[j]["latitude"], G.nodes[j]["longitude"])
+            G[i][j]["weight"] = d
+            G[j][i]["weight"] = d
+
+    # 사용자 위치에서 가장 가까운 장소를 startidx로 함
+    start_idx = None
+    if mylat is not None and mylng is not None:
+        start_idx = find_nearest_place(places, mylat, mylng)
+
+    return G, start_idx
+
+# 카테고리 제약 조건 확인
+def check_type(places, path):
+    # 전체 장소 카테고리 수 확인
+    categories = [places[i].get("type") for i in path]
+    category_set = set(categories)
+
+    print(f"경로 카테고리: {categories}")
+    print(f"카테고리 종류: {category_set}")
+    
+    # 만약 FD6와 CE7만 있다면 제약조건 무시 (예외 처리)
+    if category_set <= {"FD6", "CE7"}:
+        print("FD6와 CE7만 있어 제약조건 무시함")
+        return True
+        
+    for i in range(len(path)-1):
+        a, b = places[i], places[i+1]
+        a_type = a.get("type")
+        b_type = b.get("type")
+        print(f"검사: {i}번째({a_type}) → {i+1}번째({b_type})")
+
+        # 관광 <-> 문화 연속 제한, 다른 선택지가 없으면 허용
+        if (a.get("type") == "AT4" and b.get("type") == "CT1") or \
+            (a.get("type") == "CT1" and b.get("type") == "AT4"):
+            print(f"  ❌ 관광↔문화 연속 배치됨")
+            # 경로의 길이가 짧으면(선택지가 적으면) 허용
+            if len(path) <= 4:
+                print("  ✅ 경로가 짧아 제약 무시")
+                continue
+            print("  ❌ 경로 제약 위반: 관광↔문화 규칙")
+            return False
+        
+        # 식당 -> 카페가 이어서 오도록
+        if a.get("type") == "FD6" and b.get("type") != "CE7":
+            print(f"  ❌ 식당({a_type}) 다음 카페({b_type})가 아님")
+            # 타입에 카페가 없으면 무시
+            if "CE7" not in category_set:
+                print("  ✅ 카페가 없어서 제약 무시")
+                continue
+            # 카페가 있지만 경로상 배치 불가능한 경우도 허용
+            if categories.count("CE7") < categories.count("FD6"):
+                print("  ✅ 카페 수가 식당보다 적어 제약 무시")
+                continue
+            print("  ❌ 경로 제약 위반: 식당→카페 규칙")
+            return False
+
+    print("✅ 모든 제약 조건 통과!")
+    return True
+
+def tsp_route(places, cycle=False, mylat=None, mylng=None, start_idx=None, end_idx=None):
+    # 근사 TSP 경로 구하기, cycle=False 일반 경로(시작!=끝), weight 가중치 default
+    if not places:
+        return []
+
+    G, nearest_idx = build_distance_matrix(places, mylat, mylng)
+    # 사용자와 가까운 장소를 start_idx
+    if start_idx is None and nearest_idx is not None:
+        start_idx = nearest_idx
+
+    for i in range(10): # 여러번 반복해서 조건 만족하는 값 찾기
+        path = nx.approximation.traveling_salesman_problem(G, cycle=cycle, weight="weight")
+        print(f"\n===== 시도 {i+1} =====")
+
+        # path는 노드 인덱스 리스트. cycle=True면 마지막이 첫 노드로 돌아오는 형식일 수 있음.
+        def rotate_to_start(seq, start):
+            if start is None:
+                return seq
+            k = seq.index(start)
+            return seq[k:] + seq[:k]
+        
+        if start_idx is not None:
+            path = rotate_to_start(path, start_idx)
+            print(f"시작점 {start_idx}로 경로 조정")
+
+        print(f"경로: {path}")
+        if check_type(places, path):
+                print("✅ 유효한 경로 찾음!")
+                return path
+        else:
+            print("❌ 제약조건 불만족, 다시 시도")
+        
+    print("\n⚠️ 10번 시도했지만 조건 만족 경로 못 찾음, 제약 없이 반환")
+    # 조건에 만족하지 않으면 제약 없이 반환
+    path = nx.approximation.traveling_salesman_problem(G, cycle=cycle, weight="weight") 
+
+    if start_idx is not None:
+        path = rotate_to_start(path, start_idx)
+
+    return path
+
+def route_info(places, path):
+    # 동선 정보 가공
+    data = []
+    for i in path:
+        p = places[i]
+        data.append({
+            "place_name": p.get("place_name"),
+            "running_time": p.get("times"),
+            "latitude": p["location"]["latitude"],
+            "longitude": p["location"]["longitude"]
+        })
+    return data
+
+# breaktime 피해서 짜야함 (옵션)

--- a/places/views.py
+++ b/places/views.py
@@ -595,8 +595,8 @@ class PlaceRouteViewSet(viewsets.GenericViewSet):
     parameters=[
         OpenApiParameter(name="session_key", description="세션 키", required=True, type=str),
         OpenApiParameter(name="day", description="방문요일", required=True, type=str),
-        OpenApiParameter(name="x", description="경도", required=True, type=str),
-        OpenApiParameter(name="y", description="위도", required=True, type=str)
+        OpenApiParameter(name="x", description="경도", required=True, type=float),
+        OpenApiParameter(name="y", description="위도", required=True, type=float)
     ],
     summary="6.2 AI 추천 받기 / TSP 알고리즘"
   )
@@ -617,7 +617,7 @@ class PlaceRouteViewSet(viewsets.GenericViewSet):
         filter_data = tsp_route.filter(day, data)
 
         # 2) NetworkX TSP 알고리즘으로 가게간의 직선거리를 엣지 가중치로 최적 경로 구하기
-        routes = tsp_route.tsp_route(filter_data, cycle=False, mylat=x, mylng=y)
+        routes = tsp_route.tsp_route(filter_data, cycle=False, mylat=float(x), mylng=float(y))
         path = tsp_route.route_info(filter_data, routes)
 
         return Response({'session_key': session_key, 'result': path})

--- a/project/settings.py
+++ b/project/settings.py
@@ -172,6 +172,7 @@ CORS_ALLOWED_ORIGINS = [ #API 호출할 수 있는 출처 목록
   "https://127.0.0.1:8000",
   "http://localhost:5173",
   "https://sein0327.shop",
+  "https://api.sein0327.shop",
   "https://taroute.netlify.app"
 ]
 
@@ -180,9 +181,12 @@ CSRF_TRUSTED_ORIGINS = [ #CSRF 토큰 검증 통과
   "https://127.0.0.1:8000",
   "http://localhost:5173",
   "https://sein0327.shop",
+  "https://api.sein0327.shop",
   "https://taroute.netlify.app"
 ]
 CORS_ALLOW_CREDENTIALS = True #HTTP 자격증명 추가
 CSRF_COOKIE_SECURE = True #운영서버에서 True로 킬 것, http 보안!
 SESSION_COOKIE_SECURE = False #위와 동일
-SESSION_EXPIRE_AT_BROWSER_CLOSE = True #브라우저 닫으면 세션 만료
+
+SESSION_COOKIE_AGE = 86400  # 초 단위: 24시간 = 86400초
+SESSION_EXPIRE_AT_BROWSER_CLOSE = False  # 브라우저를 닫아도 세션 유지

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ colorama==0.4.6
 distro==1.9.0
 Django==5.2.5
 django-cors-headers==4.7.0
+django-extensions==4.1
 djangorestframework==3.16.1
 drf-spectacular==0.28.0
 drf-spectacular-sidecar==2025.8.1
@@ -19,15 +20,18 @@ inflection==0.5.1
 jiter==0.10.0
 jsonschema==4.25.0
 jsonschema-specifications==2025.4.1
+networkx==3.5
 openai==1.99.6
 pillow==11.3.0
 pydantic==2.11.7
 pydantic_core==2.33.2
+python-dateutil==2.9.0.post0
 python-dotenv==1.1.1
 PyYAML==6.0.2
 referencing==0.36.2
 requests==2.32.4
 rpds-py==0.27.0
+six==1.17.0
 sniffio==1.3.1
 sqlparse==0.5.3
 tqdm==4.67.1


### PR DESCRIPTION
# 🔥 Pull requests

## 👷 작업한 내용
- 프론트 서버 배포와 구분하기 위해 API 테스트 경로 변경 (settings.py)
- 동선 페이지 TSP 알고리즘 추천 로직 추가
- 영업시간 open/close 예외처리

## 🚨 참고 사항
- 영업시간이 24시간인 경우 periods가 없고, weekday 설명에만 들어가는 것 확인, 예외처리 필요
- 카카오 카테고리 코드가 안나오는 장소들 확인 필요

## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?
- [x] 전체 변경사항이 500줄을 넘지 않는가?

## 📟 관련 이슈

- Resolved: #29 
